### PR TITLE
Removed unnecessary explicit requirement specifications for Django.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Django==3.1.0
 djangorestframework==3.6
 openpyxl==2.4

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/workhere/drf-spreadsheets",
     packages=setuptools.find_packages(),
-    install_requires=["Django>=3.1", "djangorestframework>=3.6", "openpyxl>=2.4"],
+    install_requires=["djangorestframework>=3.6", "openpyxl>=2.4"],
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Removed the requirement for Django altogether as it was an unnecessary restriction. (Especially the fact that it required the newest version.) The code, in its current form, does not directly depend on Django at all. As long as it has the right version of DRF installed, it should work.